### PR TITLE
fix: SHA-pin all 3rd-party GitHub Actions (supply chain hardening)

### DIFF
--- a/.github/workflows/ci-azure-onboarding-script.yaml
+++ b/.github/workflows/ci-azure-onboarding-script.yaml
@@ -23,7 +23,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.CI_PROD_CRED_SECRET }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Upload AWS Fetching Template
-        uses: jakejarvis/s3-sync-action@master
+        uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311 # master
         with:
           args: --acl public-read --follow-symlinks --exclude='*' --include='azure_onboarding.ps1'
         env:


### PR DESCRIPTION
## Summary
Pin all 3rd-party action references to immutable SHA digests.

## Why
Mutable tags can be force-pushed by attackers to point at malicious commits (as happened with aquasecurity/trivy-action on 2026-03-19). SHA-pinned references are immutable and safe from this class of attack.

No functional changes -- all SHAs resolve to the same versions previously referenced by tag.